### PR TITLE
Fix automatic redirector selection: collect all Rucio site redirectors per file and probe complete list on workers

### DIFF
--- a/core/python/submission_backend.py
+++ b/core/python/submission_backend.py
@@ -236,7 +236,10 @@ def extract_lfn(url):
 
 
 def build_url(lfn, redirector):
-    return redirector.rstrip("/") + "/" + lfn.lstrip("/")
+    # Always use // between redirector and LFN: required for both regular
+    # redirectors (root://cmsxrootd.fnal.gov/) and site-specific test
+    # redirectors (root://xrootd-cms.infn.it//store/test/xrootd/<site>/).
+    return redirector.rstrip("/") + "//" + lfn.lstrip("/")
 
 
 def redirector_host(redirector):
@@ -386,6 +389,21 @@ if local_site:
 else:
     print("[stage-in] Local site not detected; using throughput ranking only")
 
+# Load per-file redirector list produced by _query_rucio during job preparation.
+# Falls back to the generic CMS redirectors when the file is absent (e.g. for
+# non-Rucio sources) or when a file has no Rucio-discovered site redirectors.
+import json as _json
+_site_redirectors_file = "site_redirectors.json"
+_site_redirectors: dict = {{}}
+if os.path.exists(_site_redirectors_file):
+    try:
+        with open(_site_redirectors_file) as _sr_fh:
+            _site_redirectors = _json.load(_sr_fh)
+        if _site_redirectors:
+            print(f"[stage-in] Loaded site redirectors for {{len(_site_redirectors)}} file(s)")
+    except Exception as _sr_exc:
+        print(f"[stage-in] Warning: could not read site_redirectors.json: {{_sr_exc}}")
+
 streams = os.environ.get("XRDCP_STREAMS", "4")
 urls = [u.strip() for u in file_list.split(",") if u.strip()]
 
@@ -394,7 +412,10 @@ def _best_redirector_for(url):
     lfn = extract_lfn(url)
     if not (lfn.startswith("/store/") or lfn.startswith("/eos/")):
         return url, url  # non-XRootD: keep original, no ranking
-    ranked = rank_redirectors_parallel(lfn, CMS_REDIRECTORS, local_site)
+    # Use per-file redirectors from Rucio when available; fall back to the
+    # generic CMS redirectors so there is always something to probe.
+    file_redirectors = _site_redirectors.get(lfn) or CMS_REDIRECTORS
+    ranked = rank_redirectors_parallel(lfn, file_redirectors, local_site)
     if not ranked:
         return url, GLOBAL_REDIRECTOR
     best_redir = ranked[0][0]
@@ -402,7 +423,8 @@ def _best_redirector_for(url):
     print(f"  [stage-in] {{lfn}} -> {{best_redir}} ({{ranked[0][1]:.2f}} MB/s)")
     return url, best_url
 
-print(f"[stage-in] Probing {{len(CMS_REDIRECTORS)}} redirector(s) for {{len(urls)}} file(s) in parallel...")
+n_redirectors = len(next(iter(_site_redirectors.values()), CMS_REDIRECTORS))
+print(f"[stage-in] Probing up to {{n_redirectors}} redirector(s) per file for {{len(urls)}} file(s) in parallel...")
 best_urls = {{}}
 with ThreadPoolExecutor(max_workers=len(urls) or 1) as pool:
     futures = {{pool.submit(_best_redirector_for, u): u for u in urls}}
@@ -420,15 +442,11 @@ local_paths = []
 for i, url in enumerate(urls):
     local_name = f"input_{{i}}.root"
     best_url = best_urls.get(url, url)
-    # Normalise test redirectors
-    best_url = _normalize_test_redirector(best_url)
 
     success = False
     for attempt in range(1, MAX_ATTEMPTS + 1):
         # After initial failure, fall back to the global redirector.
         cur_url = best_url if attempt == 1 else build_url(extract_lfn(url), GLOBAL_REDIRECTOR)
-        if attempt > 1:
-            cur_url = _normalize_test_redirector(cur_url)
         print(f"[stage-in] attempt {{attempt}}/{{MAX_ATTEMPTS}} xrdcp {{cur_url}} -> {{local_name}}")
         try:
             subprocess.run(
@@ -774,7 +792,10 @@ def extract_lfn(url):
 
 
 def build_url(lfn, redirector):
-    return redirector.rstrip("/") + "/" + lfn.lstrip("/")
+    # Always use // between redirector and LFN: required for both regular
+    # redirectors (root://cmsxrootd.fnal.gov/) and site-specific test
+    # redirectors (root://xrootd-cms.infn.it//store/test/xrootd/<site>/).
+    return redirector.rstrip("/") + "//" + lfn.lstrip("/")
 
 
 def redirector_host(redirector):
@@ -936,11 +957,28 @@ if local_site:
 else:
     print("[xrd-opt] Local site not detected; using throughput ranking only")
 
-print(f"[xrd-opt] Probing {{len(CMS_REDIRECTORS)}} redirector(s) for {{len(xrd_files)}} file(s)...")
+# Load per-file redirector list produced by _query_rucio during job preparation.
+# Falls back to the generic CMS_REDIRECTORS when absent (non-Rucio sources).
+import json as _json
+_site_redirectors_file = "site_redirectors.json"
+_site_redirectors: dict = {{}}
+if os.path.exists(_site_redirectors_file):
+    try:
+        with open(_site_redirectors_file) as _sr_fh:
+            _site_redirectors = _json.load(_sr_fh)
+        if _site_redirectors:
+            print(f"[xrd-opt] Loaded site redirectors for {{len(_site_redirectors)}} file(s)")
+    except Exception as _sr_exc:
+        print(f"[xrd-opt] Warning: could not read site_redirectors.json: {{_sr_exc}}")
+
+n_redirectors = len(next(iter(_site_redirectors.values()), CMS_REDIRECTORS)) if _site_redirectors else len(CMS_REDIRECTORS)
+print(f"[xrd-opt] Probing up to {{n_redirectors}} redirector(s) per file for {{len(xrd_files)}} file(s)...")
 optimized = []
 for f in files:
     if f.startswith("root://") or f.startswith("/store/"):
-        optimized.append(select_best_url(f, CMS_REDIRECTORS, local_site, blacklist))
+        lfn = extract_lfn(f)
+        file_redirectors = _site_redirectors.get(lfn) or CMS_REDIRECTORS
+        optimized.append(select_best_url(f, file_redirectors, local_site, blacklist))
     else:
         optimized.append(f)
 
@@ -1160,6 +1198,7 @@ def generate_condor_submit(
         f"{main_dir}/job_$(Process)/{config_file}",
         f"{main_dir}/job_$(Process)/floats.txt",
         f"{main_dir}/job_$(Process)/ints.txt",
+        f"{main_dir}/job_$(Process)/site_redirectors.json",
     ]
     if shared_dir_name:
         transfer_files.append(f"{main_dir}/{shared_dir_name}")

--- a/law/analysis_tasks.py
+++ b/law/analysis_tasks.py
@@ -1149,6 +1149,31 @@ def _write_job_config(
                 fh.write(f"{key}={val}\n")
 
 
+def _extract_lfn_for_redirect(url: str) -> str:
+    """Extract the bare LFN from an XRootD URL for site_redirectors lookup.
+
+    Handles both regular XRootD URLs (``root://host//store/...``) and
+    site-specific test redirector URLs
+    (``root://xrootd-cms.infn.it//store/test/xrootd/<site>//store/...``).
+    Returns the logical file name starting with ``/store/`` or ``/eos/``,
+    or the original *url* if it is not an XRootD URL.
+    """
+    import re as _re
+    if not url.startswith("root://"):
+        return url
+    # Strip the server component to get the path.
+    m = _re.match(r"root://[^/]+/+(.*)", url)
+    if not m:
+        return url
+    path = "/" + m.group(1).lstrip("/")
+    # For site-specific test redirectors the path is
+    # /store/test/xrootd/<site>//store/... — extract the actual LFN.
+    test_m = _re.match(r"/store/test/xrootd/[^/]+/(.*)", path)
+    if test_m:
+        path = "/" + test_m.group(1).lstrip("/")
+    return path
+
+
 def _plan_file_source_jobs(
     *,
     dataset_manifest_path: str,
@@ -1173,6 +1198,9 @@ def _plan_file_source_jobs(
         dataset_name = payload.get("sample", json_path.stem)
         all_files = payload.get("files", [])
         groups = payload.get("groups", [])
+        # Per-file redirector list from Rucio discovery (may be absent for
+        # non-Rucio sources or explicit file lists).
+        site_redirectors: dict[str, list[str]] = payload.get("site_redirectors", {})
 
         # Prefer pre-computed group partitions when available (e.g. from GetNANOFileList).
         # If the file list is empty but groups exist, we still want to create jobs.
@@ -1197,6 +1225,17 @@ def _plan_file_source_jobs(
         dtype = dataset_entry.dtype if dataset_entry else "mc"
 
         for sub_idx, part in enumerate(partitions):
+            # Build per-job site_redirectors: only include LFNs in this partition.
+            job_lfns = [
+                _extract_lfn_for_redirect(u.strip())
+                for u in str(part["files"]).split(",")
+                if u.strip()
+            ]
+            job_site_redirectors = {
+                lfn: site_redirectors[lfn]
+                for lfn in job_lfns
+                if lfn in site_redirectors
+            }
             job_plans.append({
                 "dataset_name": dataset_name,
                 "job_dir": os.path.join(jobs_dir, dataset_name, f"job_{sub_idx}"),
@@ -1205,6 +1244,7 @@ def _plan_file_source_jobs(
                 "first_entry": part.get("first_entry", 0),
                 "last_entry": part.get("last_entry", 0),
                 "dtype": dtype,
+                "site_redirectors": job_site_redirectors,
             })
 
     if missing_datasets:
@@ -1678,6 +1718,13 @@ class PrepareSkimJobs(AnalysisMixin, SkimMixin, law.Task):
                     stage_shared_inputs_locally=False,
                 )
 
+                # Write the per-job site redirector list so Condor workers
+                # can probe all available sites instead of only the generic
+                # CMS_REDIRECTORS.
+                job_site_redirectors = plan.get("site_redirectors", {})
+                with open(os.path.join(job_dir, "site_redirectors.json"), "w") as sr_fh:
+                    json.dump(job_site_redirectors, sr_fh)
+
                 job_entries.append({
                     "dataset_name": dataset_name,
                     "job_dir": job_dir,
@@ -1699,6 +1746,10 @@ class PrepareSkimJobs(AnalysisMixin, SkimMixin, law.Task):
                     output_dir=out_dir,
                     stage_shared_inputs_locally=False,
                 )
+                # Write empty site_redirectors.json so Condor transfer works
+                # consistently; workers fall back to CMS_REDIRECTORS when empty.
+                with open(os.path.join(job_dir, "site_redirectors.json"), "w") as sr_fh:
+                    json.dump({}, sr_fh)
                 job_entries.append({
                     "dataset_name": entry.name,
                     "job_dir": job_dir,

--- a/law/rucio_tasks.py
+++ b/law/rucio_tasks.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -209,7 +210,26 @@ def _query_rucio(
 
     for filedata in replicas:
         size_gb = filedata.get("bytes", 0) * 1e-9
+
+        # Select a site-specific redirector when a whitelisted site holds a
+        # replica, mirroring the behaviour of the legacy queryRucio helper.
         redirector = RUCIO_REDIRECTOR
+        states = filedata.get("states", {})
+        for site_key, state_val in states.items():
+            if state_val == "AVAILABLE" and "Tape" not in site_key:
+                site = site_key.replace("_Disk", "")
+                if site in whitelist:
+                    redirector = f"root://xrootd-cms.infn.it//store/test/xrootd/{site}/"
+                    break
+
+        # Strip any existing redirector from the file name so we always
+        # apply the chosen redirector to the bare LFN.
+        file_name = filedata["name"]
+        if file_name.startswith("root://"):
+            m = re.match(r"root://[^/]+/(.*)", file_name)
+            if m:
+                file_name = "/" + m.group(1).lstrip("/")
+
         running_size += size_gb
         running_files += 1
         if running_size > file_split_gb or running_files >= max_files_per_group:
@@ -217,7 +237,7 @@ def _query_rucio(
             running_size = size_gb
             running_files = 1
 
-        url = ensure_xrootd_redirector(filedata["name"], redirector)
+        url = ensure_xrootd_redirector(file_name, redirector)
         if group in groups:
             groups[group] += "," + url
             group_counts[group] += 1

--- a/law/rucio_tasks.py
+++ b/law/rucio_tasks.py
@@ -223,12 +223,14 @@ def _query_rucio(
                     break
 
         # Strip any existing redirector from the file name so we always
-        # apply the chosen redirector to the bare LFN.
+        # apply the chosen redirector to the bare LFN.  Match one or more
+        # slashes after the host to handle both "root://host/store/..." and
+        # "root://host//store/..." forms.
         file_name = filedata["name"]
         if file_name.startswith("root://"):
-            m = re.match(r"root://[^/]+/(.*)", file_name)
+            m = re.match(r"root://[^/]+/+(.*)", file_name)
             if m:
-                file_name = "/" + m.group(1).lstrip("/")
+                file_name = "/" + m.group(1)
 
         running_size += size_gb
         running_files += 1

--- a/law/rucio_tasks.py
+++ b/law/rucio_tasks.py
@@ -128,6 +128,14 @@ def _get_rucio_client(proxy: str | None = None):
         raise RuntimeError(f"Cannot create Rucio client: {e}") from e
 
 
+# Generic CMS XRootD redirectors used as fallbacks in the per-file redirector list.
+_CMS_FALLBACK_REDIRECTORS: list[str] = [
+    "root://cmsxrootd.fnal.gov/",
+    "root://xrootd-cms.infn.it/",
+    "root://cms-xrd-global.cern.ch/",
+]
+
+
 def _query_rucio(
     dataset_path: str,
     file_split_gb: float,
@@ -136,11 +144,18 @@ def _query_rucio(
     site_override: str,
     client,
     max_files_per_group: int = 50,
-) -> dict[int, str]:
-    """Query Rucio for replicas of *dataset_path* and return grouped URL strings.
+) -> dict:
+    """Query Rucio for replicas of *dataset_path* and return grouped URL strings
+    together with a complete per-file redirector list for site-aware probing on
+    the worker node.
 
     Files are grouped so that each group contains at most *max_files_per_group*
-    files and at most *file_split_gb* GB of data.
+    files and at most *file_split_gb* GB of data.  The URL stored in each group
+    uses the generic global redirector so that it is always reachable as a
+    fallback.  The per-file redirector list (``"site_redirectors"`` key) contains
+    ALL available site-specific redirectors for every file, plus the three generic
+    CMS redirectors as fallbacks.  Workers use this list to probe each candidate
+    site in parallel and select the fastest one.
 
     Parameters
     ----------
@@ -149,10 +164,10 @@ def _query_rucio(
     file_split_gb:
         Maximum GB of data per job group.
     whitelist:
-        Preferred site names; if a replica is available at one of these sites
-        a site-specific redirector is used.
+        Preferred site names.  No longer used for URL selection (all available
+        sites are now collected), but kept for API compatibility.
     blacklist:
-        Site names to skip.
+        Site names to skip when collecting site-specific redirectors.
     site_override:
         If non-empty, force this specific site for all replicas.
     client:
@@ -162,13 +177,19 @@ def _query_rucio(
 
     Returns
     -------
-    dict[int, str]
-        Mapping ``{group_index: "url1,url2,..."}`` where each value is a
-        comma-separated string of XRootD URLs belonging to that group.
+    dict
+        ``{"groups": dict[int, str], "site_redirectors": dict[str, list[str]]}``
+
+        * ``"groups"`` maps ``group_index`` to a comma-separated string of
+          XRootD URLs (using the global redirector as a reliable fallback).
+        * ``"site_redirectors"`` maps each bare LFN to the ordered list of
+          redirectors that should be probed on the worker node.  Site-specific
+          redirectors (from Rucio ``states``) come first, followed by the
+          generic CMS fallbacks so that the worker always has a usable option.
     """
     if not dataset_path or not isinstance(dataset_path, str) or not dataset_path.startswith("/"):
         print(f"Warning: invalid Rucio dataset path: {dataset_path!r} – skipping")
-        return {}
+        return {"groups": {}, "site_redirectors": {}}
 
     max_retries = 5
     backoff = 0.5
@@ -192,18 +213,19 @@ def _query_rucio(
                     f"Error: Rucio failed for {dataset_path!r} after "
                     f"{max_retries} attempts: {e}"
                 )
-                return {}
+                return {"groups": {}, "site_redirectors": {}}
         except Exception as e:
             print(f"Error: unexpected Rucio error for {dataset_path!r}: {e}")
-            return {}
+            return {"groups": {}, "site_redirectors": {}}
 
     if not replicas:
         print(f"Warning: no replicas found for {dataset_path!r}")
-        return {}
+        return {"groups": {}, "site_redirectors": {}}
 
     groups: dict[int, str] = {}
     group_sizes: dict[int, float] = {}
     group_counts: dict[int, int] = {}
+    per_file_redirectors: dict[str, list[str]] = {}
     running_size = 0.0
     running_files = 0
     group = 0
@@ -211,26 +233,43 @@ def _query_rucio(
     for filedata in replicas:
         size_gb = filedata.get("bytes", 0) * 1e-9
 
-        # Select a site-specific redirector when a whitelisted site holds a
-        # replica, mirroring the behaviour of the legacy queryRucio helper.
-        redirector = RUCIO_REDIRECTOR
-        states = filedata.get("states", {})
-        for site_key, state_val in states.items():
-            if state_val == "AVAILABLE" and "Tape" not in site_key:
-                site = site_key.replace("_Disk", "")
-                if site in whitelist:
-                    redirector = f"root://xrootd-cms.infn.it//store/test/xrootd/{site}/"
-                    break
-
-        # Strip any existing redirector from the file name so we always
-        # apply the chosen redirector to the bare LFN.  Match one or more
-        # slashes after the host to handle both "root://host/store/..." and
-        # "root://host//store/..." forms.
+        # Strip any existing redirector from the file name so we always work
+        # with a bare LFN.  Match one or more slashes after the host to handle
+        # both "root://host/store/..." and "root://host//store/..." forms.
         file_name = filedata["name"]
         if file_name.startswith("root://"):
             m = re.match(r"root://[^/]+/+(.*)", file_name)
             if m:
                 file_name = "/" + m.group(1)
+
+        # Collect ALL available site-specific redirectors for this file so the
+        # worker can probe each one and pick the fastest.  Every AVAILABLE
+        # non-Tape site (not on the blacklist) contributes a site-specific
+        # test redirector of the form:
+        #   root://xrootd-cms.infn.it//store/test/xrootd/<site>/
+        # The generic CMS redirectors are appended as fallbacks so the worker
+        # can always reach the file even if all site-specific probes fail.
+        states = filedata.get("states", {})
+        site_redirectors: list[str] = []
+        seen_redirectors: set[str] = set()
+        for site_key, state_val in states.items():
+            if state_val != "AVAILABLE" or "Tape" in site_key:
+                continue
+            site = site_key.replace("_Disk", "")
+            # Skip blacklisted sites.
+            if blacklist and any(b.lower() in site.lower() for b in blacklist):
+                continue
+            redir = f"root://xrootd-cms.infn.it//store/test/xrootd/{site}/"
+            if redir not in seen_redirectors:
+                site_redirectors.append(redir)
+                seen_redirectors.add(redir)
+        # Append the generic CMS redirectors as fallbacks (deduplicated).
+        for fb in _CMS_FALLBACK_REDIRECTORS:
+            if fb not in seen_redirectors:
+                site_redirectors.append(fb)
+                seen_redirectors.add(fb)
+
+        per_file_redirectors[file_name] = site_redirectors
 
         running_size += size_gb
         running_files += 1
@@ -239,7 +278,10 @@ def _query_rucio(
             running_size = size_gb
             running_files = 1
 
-        url = ensure_xrootd_redirector(file_name, redirector)
+        # The URL stored in groups uses the global redirector as a reliable
+        # fallback.  The worker will replace it with the fastest available URL
+        # after probing the per-file redirector list.
+        url = ensure_xrootd_redirector(file_name, RUCIO_REDIRECTOR)
         if group in groups:
             groups[group] += "," + url
             group_counts[group] += 1
@@ -249,7 +291,7 @@ def _query_rucio(
             group_counts[group] = 1
             group_sizes[group] = round(size_gb, 1)
 
-    return groups
+    return {"groups": groups, "site_redirectors": per_file_redirectors}
 
 
 def _get_sample_list(config_file: str):
@@ -440,6 +482,7 @@ class GetRucioFileList(RucioMixin, law.LocalWorkflow):
         all_urls: list[str] = []
         seen_urls: set[str] = set()
         rucio_groups: list[str] = []
+        all_site_redirectors: dict[str, list[str]] = {}
 
         # Explicit file list overrides Rucio discovery
         explicit_files = [
@@ -498,10 +541,13 @@ class GetRucioFileList(RucioMixin, law.LocalWorkflow):
                                 f"Rucio query failed for entry {entry!r}: {exc}"
                             ) from exc
 
+            all_site_redirectors: dict[str, list[str]] = {}
             for das_entry in das_entries:
-                partial = partial_results.get(das_entry, {})
-                for gkey in sorted(partial.keys()):
-                    group_str = partial[gkey]
+                result = partial_results.get(das_entry, {"groups": {}, "site_redirectors": {}})
+                partial_groups = result.get("groups", {})
+                partial_site_redir = result.get("site_redirectors", {})
+                for gkey in sorted(partial_groups.keys()):
+                    group_str = partial_groups[gkey]
                     group_urls = [
                         u.strip() for u in group_str.split(",") if u.strip()
                     ]
@@ -510,6 +556,7 @@ class GetRucioFileList(RucioMixin, law.LocalWorkflow):
                         seen_urls.update(new_urls)
                         all_urls.extend(new_urls)
                         rucio_groups.append(",".join(new_urls))
+                all_site_redirectors.update(partial_site_redir)
         else:
             self.publish_message(
                 f"No Rucio path or explicit files for sample {name!r}; "
@@ -526,6 +573,8 @@ class GetRucioFileList(RucioMixin, law.LocalWorkflow):
         payload: dict = {"sample": name, "files": fixed_urls}
         if rucio_groups:
             payload["groups"] = rucio_groups
+        if all_site_redirectors:
+            payload["site_redirectors"] = all_site_redirectors
 
         Path(self.output().path).parent.mkdir(parents=True, exist_ok=True)
         with open(self.output().path, "w") as fh:

--- a/law/test_nano_tasks.py
+++ b/law/test_nano_tasks.py
@@ -64,8 +64,8 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
         groups = mod._query_rucio(
             "/store/data/Run2018A/Charmonium/MINIAOD/17Sep2018-v1",
             file_split_gb=10.0,
-            WL=[],
-            BL=[],
+            whitelist=[],
+            blacklist=[],
             site_override="",
             client=client,
         )
@@ -89,8 +89,8 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
         groups = mod._query_rucio(
             "/store/data/Run2018A/MINIAOD",
             file_split_gb=10.0,
-            WL=[],
-            BL=[],
+            whitelist=[],
+            blacklist=[],
             site_override="",
             client=client,
         )
@@ -100,7 +100,8 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
             self.assertTrue(url.startswith("root://"))
 
     def test_site_override_redirector_applied(self):
-        """With a site override the site-specific redirector is still an XRootD URL."""
+        """When a file is available at a whitelisted site, the site-specific
+        redirector is used instead of the generic CMS global redirector."""
         mod = self._import()
         lfn = "/store/data/Run2018A/Charmonium/foo.root"
         entry = self._make_rucio_entry(lfn, states={"T2_US_Nebraska_Disk": "AVAILABLE"})
@@ -112,8 +113,8 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
         groups = mod._query_rucio(
             "/store/data/Run2018A/MINIAOD",
             file_split_gb=10.0,
-            WL=["T2_US_Nebraska"],
-            BL=[],
+            whitelist=["T2_US_Nebraska"],
+            blacklist=[],
             site_override="",
             client=client,
         )
@@ -122,6 +123,58 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
             self.assertTrue(
                 url.startswith("root://"),
                 f"Expected root:// prefix but got: {url!r}",
+            )
+            # Must use the site-specific redirector path, not the generic CMS one
+            self.assertIn(
+                "T2_US_Nebraska",
+                url,
+                f"Expected site-specific redirector for T2_US_Nebraska but got: {url!r}",
+            )
+            self.assertNotIn(
+                "cms-xrd-global.cern.ch",
+                url,
+                f"Expected site-specific redirector but got generic CMS global: {url!r}",
+            )
+
+    def test_existing_redirector_stripped_before_site_specific_applied(self):
+        """When Rucio returns a full XRootD URL with an existing redirector and a
+        whitelisted site is available, the existing redirector is stripped first
+        and the site-specific one is applied instead."""
+        mod = self._import()
+        # Rucio returns a full URL with an old/generic redirector already embedded
+        full_url = "root://cms-xrd-global.cern.ch//store/data/Run2018A/foo.root"
+        entry = self._make_rucio_entry(
+            full_url, states={"T2_US_Nebraska_Disk": "AVAILABLE"}
+        )
+
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.list_replicas.return_value = iter([entry])
+
+        groups = mod._query_rucio(
+            "/store/data/Run2018A/MINIAOD",
+            file_split_gb=10.0,
+            whitelist=["T2_US_Nebraska"],
+            blacklist=[],
+            site_override="",
+            client=client,
+        )
+        all_urls = ",".join(groups.values()).split(",")
+        for url in all_urls:
+            self.assertTrue(url.startswith("root://"))
+            # The result must not contain a double redirector (old one + new one)
+            self.assertNotIn("root://root://", url, "Double-prefix detected")
+            # The original generic redirector must have been removed
+            self.assertNotIn(
+                "cms-xrd-global.cern.ch//store/data",
+                url,
+                f"Original generic redirector was not stripped: {url!r}",
+            )
+            # The site-specific redirector must now be present
+            self.assertIn(
+                "T2_US_Nebraska",
+                url,
+                f"Expected site-specific redirector for T2_US_Nebraska but got: {url!r}",
             )
 
 

--- a/law/test_nano_tasks.py
+++ b/law/test_nano_tasks.py
@@ -170,11 +170,13 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
                 url,
                 f"Original generic redirector was not stripped: {url!r}",
             )
-            # The site-specific redirector must now be present
-            self.assertIn(
-                "T2_US_Nebraska",
+            # The site-specific redirector must now be present, and the LFN
+            # path must appear after the site name without a second redirector
+            # host in between.
+            self.assertRegex(
                 url,
-                f"Expected site-specific redirector for T2_US_Nebraska but got: {url!r}",
+                r"root://xrootd-cms\.infn\.it//store/test/xrootd/T2_US_Nebraska//store/data",
+                f"Expected site-specific redirector pattern but got: {url!r}",
             )
 
 

--- a/law/test_nano_tasks.py
+++ b/law/test_nano_tasks.py
@@ -38,7 +38,7 @@ _SKIP_MSG = "law and luigi packages not available"
 
 @unittest.skipUnless(_LAW_AVAILABLE, _SKIP_MSG)
 class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
-    """Tests that _query_rucio produces XRootD URLs via ensure_xrootd_redirector."""
+    """Tests that _query_rucio produces XRootD URLs and collects site redirectors."""
 
     def _import(self):
         import nano_tasks
@@ -51,6 +51,18 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
             "bytes": size_bytes,
         }
 
+    # ------------------------------------------------------------------
+    # Helper: extract groups and site_redirectors from the new return type
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _groups(result):
+        return result.get("groups", {})
+
+    @staticmethod
+    def _site_redirectors(result):
+        return result.get("site_redirectors", {})
+
     def test_bare_lfn_gets_redirector(self):
         """A bare LFN from Rucio gets the default CMS redirector prepended."""
         mod = self._import()
@@ -61,7 +73,7 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
         client = MagicMock()
         client.list_replicas.return_value = iter([entry])
 
-        groups = mod._query_rucio(
+        result = mod._query_rucio(
             "/store/data/Run2018A/Charmonium/MINIAOD/17Sep2018-v1",
             file_split_gb=10.0,
             whitelist=[],
@@ -69,12 +81,21 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
             site_override="",
             client=client,
         )
+        groups = self._groups(result)
         all_urls = ",".join(groups.values()).split(",")
         for url in all_urls:
             self.assertTrue(
                 url.startswith("root://"),
                 f"Expected root:// prefix but got: {url!r}",
             )
+        # Without Rucio state information, site_redirectors should contain
+        # only the generic CMS fallback redirectors.
+        site_redirs = self._site_redirectors(result)
+        self.assertIn(lfn, site_redirs, "LFN should appear in site_redirectors")
+        for fb in ["root://cmsxrootd.fnal.gov/", "root://xrootd-cms.infn.it/",
+                   "root://cms-xrd-global.cern.ch/"]:
+            self.assertIn(fb, site_redirs[lfn],
+                          f"Generic fallback redirector {fb!r} should be in list")
 
     def test_full_xrootd_lfn_not_double_prefixed(self):
         """If Rucio returns a name already starting with root://, it is not double-prefixed."""
@@ -86,7 +107,7 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
         client = MagicMock()
         client.list_replicas.return_value = iter([entry])
 
-        groups = mod._query_rucio(
+        result = mod._query_rucio(
             "/store/data/Run2018A/MINIAOD",
             file_split_gb=10.0,
             whitelist=[],
@@ -94,23 +115,38 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
             site_override="",
             client=client,
         )
+        groups = self._groups(result)
         all_urls = ",".join(groups.values()).split(",")
         for url in all_urls:
             self.assertNotIn("root://root://", url, "Double-prefix detected")
             self.assertTrue(url.startswith("root://"))
+        # The extracted LFN (/store/data/Run2018A/foo.root) should appear in
+        # site_redirectors (not the full URL with original redirector).
+        site_redirs = self._site_redirectors(result)
+        lfn = "/store/data/Run2018A/foo.root"
+        self.assertIn(lfn, site_redirs,
+                      "Extracted LFN should be the key in site_redirectors")
 
-    def test_site_override_redirector_applied(self):
-        """When a file is available at a whitelisted site, the site-specific
-        redirector is used instead of the generic CMS global redirector."""
+    def test_site_specific_redirectors_collected_for_available_sites(self):
+        """All AVAILABLE non-Tape sites produce site-specific redirectors in
+        site_redirectors; the URL in groups uses the global redirector as
+        a reliable fallback (the worker picks the actual best site)."""
         mod = self._import()
         lfn = "/store/data/Run2018A/Charmonium/foo.root"
-        entry = self._make_rucio_entry(lfn, states={"T2_US_Nebraska_Disk": "AVAILABLE"})
+        entry = self._make_rucio_entry(
+            lfn,
+            states={
+                "T2_US_Nebraska_Disk": "AVAILABLE",
+                "T2_DE_RWTH_Disk": "AVAILABLE",
+                "T1_US_FNAL_Tape": "AVAILABLE",   # Tape – must be excluded
+            },
+        )
 
         from unittest.mock import MagicMock
         client = MagicMock()
         client.list_replicas.return_value = iter([entry])
 
-        groups = mod._query_rucio(
+        result = mod._query_rucio(
             "/store/data/Run2018A/MINIAOD",
             file_split_gb=10.0,
             whitelist=["T2_US_Nebraska"],
@@ -118,28 +154,78 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
             site_override="",
             client=client,
         )
-        all_urls = ",".join(groups.values()).split(",")
-        for url in all_urls:
-            self.assertTrue(
-                url.startswith("root://"),
-                f"Expected root:// prefix but got: {url!r}",
-            )
-            # Must use the site-specific redirector path, not the generic CMS one
-            self.assertIn(
-                "T2_US_Nebraska",
-                url,
-                f"Expected site-specific redirector for T2_US_Nebraska but got: {url!r}",
-            )
-            self.assertNotIn(
-                "cms-xrd-global.cern.ch",
-                url,
-                f"Expected site-specific redirector but got generic CMS global: {url!r}",
-            )
 
-    def test_existing_redirector_stripped_before_site_specific_applied(self):
-        """When Rucio returns a full XRootD URL with an existing redirector and a
-        whitelisted site is available, the existing redirector is stripped first
-        and the site-specific one is applied instead."""
+        groups = self._groups(result)
+        all_urls = ",".join(groups.values()).split(",")
+        # The URL stored in groups uses the global redirector (not site-specific).
+        for url in all_urls:
+            self.assertTrue(url.startswith("root://"))
+            self.assertIn("cms-xrd-global.cern.ch", url,
+                          "Groups URL should use the global redirector as fallback")
+
+        site_redirs = self._site_redirectors(result)
+        self.assertIn(lfn, site_redirs)
+        redir_list = site_redirs[lfn]
+
+        # Both disk sites should appear as site-specific redirectors.
+        self.assertTrue(
+            any("T2_US_Nebraska" in r for r in redir_list),
+            f"T2_US_Nebraska should be in site_redirectors, got: {redir_list}",
+        )
+        self.assertTrue(
+            any("T2_DE_RWTH" in r for r in redir_list),
+            f"T2_DE_RWTH should be in site_redirectors, got: {redir_list}",
+        )
+        # Tape sites must NOT appear.
+        self.assertFalse(
+            any("T1_US_FNAL" in r for r in redir_list),
+            f"Tape site T1_US_FNAL should NOT be in site_redirectors, got: {redir_list}",
+        )
+        # Generic CMS fallback redirectors must also be present.
+        for fb in ["root://cmsxrootd.fnal.gov/", "root://cms-xrd-global.cern.ch/"]:
+            self.assertIn(fb, redir_list,
+                          f"Generic fallback {fb!r} should be in site_redirectors")
+
+    def test_blacklisted_site_excluded_from_redirectors(self):
+        """Sites on the blacklist must not appear in site_redirectors."""
+        mod = self._import()
+        lfn = "/store/data/Run2018A/Charmonium/foo.root"
+        entry = self._make_rucio_entry(
+            lfn,
+            states={
+                "T2_US_Nebraska_Disk": "AVAILABLE",
+                "T2_DE_RWTH_Disk": "AVAILABLE",
+            },
+        )
+
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.list_replicas.return_value = iter([entry])
+
+        result = mod._query_rucio(
+            "/store/data/Run2018A/MINIAOD",
+            file_split_gb=10.0,
+            whitelist=[],
+            blacklist=["T2_US_Nebraska"],
+            site_override="",
+            client=client,
+        )
+        site_redirs = self._site_redirectors(result)
+        self.assertIn(lfn, site_redirs)
+        redir_list = site_redirs[lfn]
+        self.assertFalse(
+            any("T2_US_Nebraska" in r for r in redir_list),
+            f"Blacklisted site T2_US_Nebraska should NOT appear, got: {redir_list}",
+        )
+        # T2_DE_RWTH (not blacklisted) must still be present.
+        self.assertTrue(
+            any("T2_DE_RWTH" in r for r in redir_list),
+            f"T2_DE_RWTH (not blacklisted) should still be in site_redirectors",
+        )
+
+    def test_existing_redirector_stripped_before_lfn_extracted(self):
+        """When Rucio returns a full XRootD URL with an existing redirector, the
+        LFN is correctly extracted and used as the key in site_redirectors."""
         mod = self._import()
         # Rucio returns a full URL with an old/generic redirector already embedded
         full_url = "root://cms-xrd-global.cern.ch//store/data/Run2018A/foo.root"
@@ -151,7 +237,7 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
         client = MagicMock()
         client.list_replicas.return_value = iter([entry])
 
-        groups = mod._query_rucio(
+        result = mod._query_rucio(
             "/store/data/Run2018A/MINIAOD",
             file_split_gb=10.0,
             whitelist=["T2_US_Nebraska"],
@@ -159,25 +245,23 @@ class TestQueryRucioRedirectorEnforcement(unittest.TestCase):
             site_override="",
             client=client,
         )
+        # The URL in groups should use the global redirector (not double-prefixed).
+        groups = self._groups(result)
         all_urls = ",".join(groups.values()).split(",")
         for url in all_urls:
             self.assertTrue(url.startswith("root://"))
-            # The result must not contain a double redirector (old one + new one)
             self.assertNotIn("root://root://", url, "Double-prefix detected")
-            # The original generic redirector must have been removed
-            self.assertNotIn(
-                "cms-xrd-global.cern.ch//store/data",
-                url,
-                f"Original generic redirector was not stripped: {url!r}",
-            )
-            # The site-specific redirector must now be present, and the LFN
-            # path must appear after the site name without a second redirector
-            # host in between.
-            self.assertRegex(
-                url,
-                r"root://xrootd-cms\.infn\.it//store/test/xrootd/T2_US_Nebraska//store/data",
-                f"Expected site-specific redirector pattern but got: {url!r}",
-            )
+
+        # The extracted LFN should be the key in site_redirectors.
+        site_redirs = self._site_redirectors(result)
+        lfn = "/store/data/Run2018A/foo.root"
+        self.assertIn(lfn, site_redirs,
+                      "Extracted LFN should be the key in site_redirectors")
+        # The site-specific redirector must appear in the list.
+        self.assertTrue(
+            any("T2_US_Nebraska" in r for r in site_redirs[lfn]),
+            f"T2_US_Nebraska should be in site_redirectors, got: {site_redirs[lfn]}",
+        )
 
 
 @unittest.skipUnless(_LAW_AVAILABLE, _SKIP_MSG)


### PR DESCRIPTION
Fixes the automatic redirector testing to check site-specific redirectors available for each file (not generic CMS ones), and extends Rucio site handling so that all possible site-specific redirectors are saved per file and sent to each job for worker-side probing.

## Changes Made

### `rucio_tasks.py`
- `_query_rucio` now returns `{"groups": ..., "site_redirectors": {lfn: [all_redirectors]}}` instead of a plain groups dict
- All AVAILABLE non-Tape, non-blacklisted Rucio states are collected as site-specific test redirectors (`root://xrootd-cms.infn.it//store/test/xrootd/<site>/`) — not just the first whitelisted site
- Generic CMS redirectors (`cmsxrootd.fnal.gov`, `xrootd-cms.infn.it`, `cms-xrd-global.cern.ch`) are appended as fallbacks for every file
- The URL stored in `groups` uses the global redirector as a reliable fallback; the worker selects the actual fastest site at runtime by probing the complete list
- Existing redirectors in Rucio-returned file names are stripped before the bare LFN is used as the `site_redirectors` key
- `GetRucioFileList._run_impl` updated to handle the new return type and write `site_redirectors` to the JSON payload

### `analysis_tasks.py`
- Added `_extract_lfn_for_redirect()` helper for extracting bare LFNs (handles site-specific test redirector URL format)
- `_plan_file_source_jobs` now extracts per-job `site_redirectors` from the JSON file-list payload and includes them in job plans
- `PrepareSkimJobs.run()` writes `site_redirectors.json` to every job directory (empty `{}` for non-Rucio jobs so Condor transfer works consistently)

### `submission_backend.py`
- `generate_condor_submit` adds `job_$(Process)/site_redirectors.json` to Condor `transfer_input_files`
- Fixed `build_url` in both worker heredocs to use `//` separator, which is required for site-specific test redirector URLs (`root://xrootd-cms.infn.it//store/test/xrootd/<site>//store/...`)
- `xrootd_optimize_block` and `stage_inputs_block` load `site_redirectors.json` when present and use the per-file redirector list for probing instead of the hardcoded `CMS_REDIRECTORS`; fall back gracefully to `CMS_REDIRECTORS` when the file is absent

### `test_nano_tasks.py`
- Tests updated to use the new `{"groups": ..., "site_redirectors": ...}` return type
- New tests verify: all AVAILABLE disk sites are collected, Tape replicas and blacklisted sites are excluded, generic fallbacks are always appended, and LFNs are correctly extracted from full XRootD URLs
- The URL stored in `groups` is verified to use the global redirector (not a site-specific one)

Co-authored-by: brkronheim <46789663+brkronheim@users.noreply.github.com>