### PR TITLE
docs: clarify role-based navigation and ROOT environment notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ cd build/analyses/ExampleAnalysis
 - **[ONNX Implementation](docs/ONNX_IMPLEMENTATION.md)** - ONNX manager details
 - **[ONNX Multi-Output](docs/ONNX_MULTI_OUTPUT.md)** - Multi-output model support
 
+
+## Documentation Paths by Audience
+
+If you are reading docs for a specific role, start here:
+
+- **Developers (framework contributors)**: `docs/ARCHITECTURE.md`, `docs/API_REFERENCE.md`, `docs/PLUGIN_DEVELOPMENT.md`, `docs/DOXYGEN_GUIDE.md`
+- **Analyzers (analysis authors)**: `docs/GETTING_STARTED.md`, `docs/ANALYSIS_GUIDE.md`, `docs/CONFIG_REFERENCE.md`, `docs/CONFIG_HISTOGRAMS.md`, `docs/NUISANCE_GROUPS.md`
+- **Agents/automation tooling**: `docs/INDEX.md`, `docs/ERRORS_AND_TRACING.md`, `docs/CONFIGURATION_VALIDATION.md`, `docs/OUTPUT_SCHEMA.md`, `docs/VALIDATION_REPORTS.md`
+
+The docs are intentionally layered: `GETTING_STARTED` and `ANALYSIS_GUIDE` show workflow, while `API_REFERENCE` and headers in `core/interface/` are the source of truth for signatures and behavior.
+
 ## Requirements
 
 - ROOT 6.30/02 or later (progress bar support requires 6.30+)
@@ -120,9 +131,8 @@ RDFAnalyzerCore/
 │   ├── interface/     # Public headers and interfaces
 │   ├── src/          # Core implementations
 │   ├── plugins/      # Plugin managers (BDT, ONNX, etc.)
-│   ├── bindings/     # Python bindings (pybind11)
 │   ├── python/       # HTCondor submission scripts
-│   └── test/         # Unit tests
+│   └── tests/        # Core test targets
 ├── analyses/          # Analysis repositories (git submodules/clones)
 ├── examples/          # Python binding examples
 ├── docs/             # Documentation

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -11,6 +11,10 @@ This guide will help you get up and running with RDFAnalyzerCore quickly — fro
 
 ## Quick Start
 
+
+> **Important:** ROOT is a C++ framework and is **not** installed via `pip install ROOT`.
+> Use `source env.sh` (CVMFS environments) or source an existing ROOT installation with `source <root-install>/bin/thisroot.sh`.
+
 ### 1. Clone the Repository
 
 ```bash

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,7 @@
 **Getting Started**
 - [Installation](./GETTING_STARTED.md) - Build requirements
 - [Quick Start](./GETTING_STARTED.md) - Minimal example
-- [Examples](./examples/config_histograms/README.md) - Working examples
+- [Examples](../examples/README.md) - Runnable examples and scripts
 
 **Analysis Guide**
 - [Building Analyses](./ANALYSIS_GUIDE.md) - Step-by-step tutorials
@@ -77,6 +77,20 @@
 - [Schema](./OUTPUT_SCHEMA.md) - Output format
 - [Validation](./VALIDATION_REPORTS.md) - Validation
 
+## Role-Based Navigation
+
+- **Developers (framework maintainers)**
+  - Start: [Architecture](./ARCHITECTURE.md)
+  - Then: [API Reference](./API_REFERENCE.md), [Plugin Development](./PLUGIN_DEVELOPMENT.md), [Doxygen Guide](./DOXYGEN_GUIDE.md)
+
+- **Analyzers (analysis builders)**
+  - Start: [Getting Started](./GETTING_STARTED.md)
+  - Then: [Analysis Guide](./ANALYSIS_GUIDE.md), [Configuration Reference](./CONFIG_REFERENCE.md), [Config Histograms](./CONFIG_HISTOGRAMS.md), [Nuisance Groups](./NUISANCE_GROUPS.md)
+
+- **Agents (automation + validation)**
+  - Start: [Documentation Index](./INDEX.md)
+  - Then: [Errors and Tracing](./ERRORS_AND_TRACING.md), [Configuration Validation](./CONFIGURATION_VALIDATION.md), [Output Schema](./OUTPUT_SCHEMA.md), [Validation Reports](./VALIDATION_REPORTS.md)
+
 ## Documentation Quality
 
 Documentation is maintained as code-adjacent guidance. For API truth, treat C++ headers in `core/interface/` as canonical and use these docs as usage-oriented references.
@@ -119,5 +133,5 @@ Current high-priority core areas:
 
 ---
 
-**Last Updated:** 2026-04-26
+**Last Updated:** 2026-05-01
 **Compatibility:** ROOT 6.30+, C++17, optional Python 3.8+

--- a/docs/PYTHON_BINDINGS.md
+++ b/docs/PYTHON_BINDINGS.md
@@ -559,6 +559,9 @@ class Analyzer:
 
 ## Configuration Files
 
+> **Environment note:** ROOT must come from CVMFS/site packages or a local ROOT build. It is not distributed as a pip package named `ROOT`; source `env.sh` or `thisroot.sh` before using Python bindings.
+
+
 Python bindings use the same configuration files as the C++ framework:
 
 ```
@@ -655,13 +658,9 @@ Common causes:
 
 ## Future Enhancements
 
-Planned features for future releases:
+Planned improvements focus on ergonomics and coverage (for example, expanded end-to-end examples and additional validation utilities).
 
-- [ ] Plugin manager bindings (BDT, ONNX, Corrections, Histograms)
-- [ ] Direct RDataFrame access for advanced users
-- [ ] Systematic variation control from Python
-- [ ] Callback functions for custom event processing
-- [ ] Helper utilities for common patterns
+Current plugin manager bindings are already available; refer to the plugin management sections above for supported APIs.
 
 ## Contributing
 

--- a/docs/PYTHON_BINDINGS_QUICKSTART.md
+++ b/docs/PYTHON_BINDINGS_QUICKSTART.md
@@ -2,6 +2,8 @@
 
 ## Installation
 
+> **Prerequisite:** Do not attempt `pip install ROOT`. Use `source env.sh` on supported hosts or `source <root-install>/bin/thisroot.sh` with a standalone ROOT installation.
+
 ```bash
 # Build RDFAnalyzerCore with Python bindings
 source env.sh  # On a CVMFS-backed host, or source your ROOT installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,12 @@ New to RDFAnalyzerCore? Start here:
 - **[Getting Started Guide](GETTING_STARTED.md)** - Installation, setup, and your first analysis
 - **[Quick Start](GETTING_STARTED.md#quick-start)** - Get running in 5 minutes
 
+## Who should read what?
+
+- **Developers**: [Architecture](ARCHITECTURE.md), [API Reference](API_REFERENCE.md), [Plugin Development](PLUGIN_DEVELOPMENT.md)
+- **Analyzers**: [Getting Started](GETTING_STARTED.md), [Analysis Guide](ANALYSIS_GUIDE.md), [Configuration Reference](CONFIG_REFERENCE.md)
+- **Agents/automation**: [INDEX](INDEX.md), [Errors and Tracing](ERRORS_AND_TRACING.md), [Validation Reports](VALIDATION_REPORTS.md)
+
 ## User Documentation
 
 ### Building Analyses


### PR DESCRIPTION
### Motivation

- Improve discoverability by surfacing role-based documentation entry points for developers, analyzers, and automation agents.
- Prevent common environment setup mistakes by clarifying that ROOT is not installed via pip and must be sourced from CVMFS or a local installation.
- Align README and index pages with updated doc paths and examples so readers can find runnable examples and config guides quickly.

### Description

- Added a "Documentation Paths by Audience" / role-based navigation section to `README.md`, `docs/INDEX.md`, and `docs/index.md` with direct links such as `docs/ARCHITECTURE.md`, `docs/GETTING_STARTED.md`, and `docs/OUTPUT_SCHEMA.md`.
- Inserted prominent environment notes in `docs/GETTING_STARTED.md`, `docs/PYTHON_BINDINGS.md`, and `docs/PYTHON_BINDINGS_QUICKSTART.md` clarifying that `ROOT` must be sourced via `env.sh` or `thisroot.sh` and is not available via `pip install ROOT`.
- Updated example links and repository structure notes in `README.md` and `docs/INDEX.md`, including renaming `core/test/` to `core/tests/` in the repository structure block.
- Minor copy edits to `docs/PYTHON_BINDINGS.md` to reframe planned enhancements and call out existing plugin bindings.

### Testing

- This is a documentation-only change; no code unit tests were modified or required to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4943a9744832f94c1c189a311f1e3)